### PR TITLE
Video.js POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ivelt-media",
   "displayName": "Ivelt Media",
-  "version": "0.2.3.1",
+  "version": "0.2.3.2",
   "author": "Mordechai Meisels",
   "description": "Adds embedded media players for linked media in ivelt.com posts.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ivelt-media",
   "displayName": "Ivelt Media",
-  "version": "0.2.3",
+  "version": "0.2.3.1",
   "author": "Mordechai Meisels",
   "description": "Adds embedded media players for linked media in ivelt.com posts.",
   "type": "module",
@@ -30,6 +30,7 @@
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
+    "video.js": "^8.12.0",
     "vite": "^4.4.11"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+
+import videojs from 'video.js'
+import 'video.js/dist/video-js.css'
+
 interface Media {
     title: string
     href: string
@@ -9,79 +13,91 @@ interface Media {
 const posts = document.querySelectorAll('.postprofile + .postbody .content, #preview .postbody .content')
 
 for (const post of posts) {
-    const links = post.querySelectorAll(`
+  const links = post.querySelectorAll(`
     .content > a[href^="https://drive.google.com/file/d/"],
     .content > :not(blockquote) a[href^="https://drive.google.com/file/d/"],
-    .content > a[href^="https://www.dropbox.com/scl/fi/"][href$="&dl=0"]:is([href*=".mp3"], [href*=".mp4"], [href*=".mov"], [href*=".m4a"], [href*=".m4v"], [href*="webm"]), 
+    .content > a[href^="https://www.dropbox.com/scl/fi/"][href$="&dl=0"]:is([href*=".mp3"], [href*=".mp4"], [href*=".mov"], [href*=".m4a"], [href*=".m4v"], [href*="webm"]),
     .content > :not(blockquote) a[href^="https://www.dropbox.com"][href$="&dl=0"]:is([href*=".mp3"], [href*=".mp4"], [href*=".mov"], [href*=".m4a"], [href*=".m4v"], [href*="webm"])
     `)
-    if (!links.length)
-        continue
+  if (!links.length)
+    continue
 
-    const media = [...links].map(l => {
-        const href = l.getAttribute('href') as string
+  const media = [...links].map(l => {
+    const href = l.getAttribute('href') as string
 
-        let id: string
-        let type: 'google-drive' | 'dropbox'
-        let filename: string | undefined
+    let id: string
+    let type: 'google-drive' | 'dropbox'
+    let filename: string | undefined
 
-        if (href.startsWith('https://drive.google.com')) {
-            const match = /^https:\/\/drive.google.com\/file\/d\/([^/]+)/.exec(href)!
+    if (href.startsWith('https://drive.google.com')) {
+      const match = /^https:\/\/drive.google.com\/file\/d\/([^/]+)/.exec(href)!
 
-            id = match[1]
-            type = 'google-drive'
-        }
+      id = match[1]
+      type = 'google-drive'
+    } else if (href.startsWith('https://www.dropbox.com')) {
+      const match = /^https:\/\/www.dropbox.com\/scl\/fi\/([^/]+)\/(.+?)\?(.+)\&dl=0/.exec(href)!
 
-        else if (href.startsWith('https://www.dropbox.com')) {
-            const match = /^https:\/\/www.dropbox.com\/scl\/fi\/([^/]+)\/(.+?)\?(.+)\&dl=0/.exec(href)!
+      filename = match[2]
+      id = `${match[1]}/${filename}?${match[3]}`
 
-            filename = match[2]
-            id = `${match[1]}/${filename}?${match[3]}`
-
-            type = 'dropbox'
-        }
-
-        else
-            throw Error('Unknown media type')
+      type = 'dropbox'
+    } else
+      throw Error('Unknown media type')
 
 
-        return {
-            title: l.textContent ?? href,
-            href,
-            id,
-            filename,
-            type
-        }
-    })
+    return {
+      title: l.textContent ?? href,
+      href,
+      id,
+      filename,
+      type,
+    }
+  })
 
-
-
-    post.insertAdjacentHTML('afterend',
-        `<div class='ivelt-media__root'>
-        ${media.map(m => `
+  const htmlData = `<div class='ivelt-media__root'>
+        ${media.map((m, index) => `
             <div class='links'>
                 <a class='button'
-                    href=${m.type === 'google-drive' ? 
+                    href=${m.type === 'google-drive' ?
                     `https://drive.google.com/uc?export=download&id=${m.id}`:
                     `https://www.dropbox.com/scl/fi/${m.id}&dl=1`}>
                 <i class='icon fa-download'></i> דאונלאויד</a>
             </div>
             <div class='container'>
             ${m.type === 'google-drive' ?
-                `<iframe 
-                    src='https://drive.google.com/file/d/${m.id}/preview' 
-                    frameborder='0' 
+                `<iframe
+                    src='https://drive.google.com/file/d/${m.id}/preview'
+                    frameborder='0'
                     loading='lazy'
                     scrolling='no'
                     allowfullscreen>
                     Your browser does not support this content
                 </iframe>`
                 :
-                `<video controls preview='metadata' filename=${m.filename}>
-                    <source src='https://www.dropbox.com/scl/fi/${m.id}&dl=1'/>
+                `<video
+                    id=vid-${post.parentElement?.id}-${index}
+                    class="video-js"
+                    controls
+                    preload="auto"
+                  >
+                  <source
+                     src=https://www.dropbox.com/scl/fi/${m.id}&dl=1
+                 />
                     Your browser does not support this content
-                </video>`
+                </video>
+                `
             }
         </div>`).join('')}
-    </div>`)
+    </div>`
+
+  post.insertAdjacentHTML('afterend', htmlData)
+
 }
+
+
+for (const videoElement of document.getElementsByClassName('video-js')) {
+  videojs(videoElement.id ,{
+    responsive: true
+  })
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ for (const post of posts) {
                 :
                 `<video
                     id=vid-${post.parentElement?.id}-${index}
-                    class="video-js"
+                    class="video-js vjs-16-9"
                     controls
                     preload="auto"
                   >
@@ -97,7 +97,7 @@ for (const post of posts) {
 
 for (const videoElement of document.getElementsByClassName('video-js')) {
   videojs(videoElement.id ,{
-    responsive: true
+  'fluid' : true
   })
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,5 @@
 .ivelt-media__root {
-  all: unset;
+  /*all: unset;*/
   margin-top: 1.5rem;
   padding: 0.75rem;
   border-left: solid #60a5fa 3px;
@@ -15,29 +15,36 @@
   }
 
   .container {
-    display: flex;
-    width: 100%;
-    aspect-ratio: 16 / 9;
+      /*margin:0;*/
+      /*padding:0;*/
+      /*background-color:rgb(38,38,38);*/
+      /*height:100%;*/
+      /*width:100%;*/
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    /*aspect-ratio: 16 / 9;*/
   }
 
-  iframe,
-  video {
+  iframe
+  {
     display: block;
     inset: 0;
     width: 100%;
     height: 100%;
+    min-height: 480px;
     max-width: 100%;
-    max-height: 100%;
+    max-height: 700px;
     background: black;
   }
 
-  /* Audio overrides */
-  .container:has(video[filename$='.mp3'], video[filename$='.m4a']) {
-    height: 50px;
-  }
+  /*!* Audio overrides *!*/
+  /*.container:has(video[filename$='.mp3'], video[filename$='.m4a']) {*/
+  /*  height: 50px;*/
+  /*}*/
 
-  video[filename$='.mp3'],
-  video[filename$='.m4a'] {
-    background: transparent;
-  }
+  /*video[filename$='.mp3'],*/
+  /*video[filename$='.m4a'] {*/
+  /*  background: transparent;*/
+  /*}*/
 }


### PR DESCRIPTION
Following our attempt to utilize iframe for Dropbox links in issue #4, I've proposed an alternate approach. Instead, we could use videojs.com as our media player

As a preliminary exploration, I wanted to test this concept and evaluate its implementation on Kiwi (@KnaperYaden).

IMPORTANT: This is not prepared for merging at the moment. It's only a proposed idea. Before merging, I would recommend refactoring the entire workflow and potentially introducing an object for managing all links and players.

### Google drive
I also attempted to integrate Google Drive with videojs. However, I encountered a roadblock when all Google Drive links returned a 403 error. After more detailed investigation (using Postman), I discovered that the browser sets a [ recently introduced cors header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site) `Sec-Fetch-Site: cross-site`, nd the google server responds with a 403 status.

If we decide to enable Google Drive functionalities, we have those options:
1. Utilise the Google Drive API. However, this would either require revealing our API key or requiring each user to generate their own, however, could be quite complex, even for advanced users.
2. host a CORS proxy like https://cors-anywhere.herokuapp.com.
3. maybe the [youtube plugin](https://github.com/videojs/videojs-youtube) would help 
4. Maintain the current strategy of using an iframe for Google Drive

At present, I've enabled preload. While it improves user experience, it could lead to limitations in the long term if Dropbox imposes rate limits associated with downloading the file each time.


The videojs player has a variety of customizable options that you can refer to at this guide.

![chrome_aZwbiaP8Kn](https://github.com/codaworks/ivelt-media/assets/94487951/1b6094d4-3f18-4414-b6a5-10b281b491e0)

I build a zip file to test
[Ivelt-Media-0.2.3.1.zip](https://github.com/codaworks/ivelt-media/files/15324547/Ivelt-Media-0.2.3.1.zip)


Updated version for commit [a1cc308](https://github.com/codaworks/ivelt-media/pull/5/commits/a1cc308f146646f4c9f3985fdeac29dbf0426ef4) [Ivelt-Media-0.2.3.2.zip](https://github.com/codaworks/ivelt-media/files/15324811/Ivelt-Media-0.2.3.2.zip)
